### PR TITLE
docs: clarify downtrend calculation

### DIFF
--- a/PatternAnalysisService.php
+++ b/PatternAnalysisService.php
@@ -1917,8 +1917,11 @@ class PatternAnalysisService
 
 
 /**
- * Check if the stock is in a downtrend
- * A downtrend = lower highs or price slope going down
+ * Determine if the stock is in a downtrend.
+ *
+ * The current implementation performs a linear regression on closing
+ * prices over the provided lookback period and treats a negative slope
+ * as a downtrend. Detection of lower highs is not implemented.
  */
 private function isDowntrend(array $ohlcData, int $lookback = 20): bool
 {


### PR DESCRIPTION
## Summary
- clarify that downtrend check uses linear regression of closing prices
- note that lower-high detection isn't implemented

## Testing
- `php -l PatternAnalysisService.php`


------
https://chatgpt.com/codex/tasks/task_e_68a441588c608327af5fe71ac96c0164