### PR TITLE
Handle mixed return input and nullable patterns

### DIFF
--- a/PatternAnalysisService.php
+++ b/PatternAnalysisService.php
@@ -1042,7 +1042,7 @@ class PatternAnalysisService
 
      */
 
-    public function detectSureshot(Stock $stock, array $patterns = null): array
+    public function detectSureshot(Stock $stock, ?array $patterns = null): array
 
     {
 
@@ -1372,7 +1372,7 @@ class PatternAnalysisService
 
 
 
-    private function calculateRiskReward(float $return, string $riskLevel): float
+    private function calculateRiskReward(float|string $return, string $riskLevel): float
 
     {
 


### PR DESCRIPTION
## Summary
- Allow nullable pattern array when detecting SURESHOT setups
- Accept percentage strings in risk-reward calculation

## Testing
- `php -l PatternAnalysisService.php`
- `./phpunit tests/CalculateRiskRewardTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a443d4c2648327b0abc34e5f8ac5d1