### PR TITLE
Use singular Head and Shoulders pattern name

### DIFF
--- a/PatternAnalysisService.php
+++ b/PatternAnalysisService.php
@@ -172,7 +172,7 @@ class PatternAnalysisService
 
         ],
 
-        'Head and Shoulders Chart Patterns' => [
+        'Head and Shoulders Chart Pattern' => [
 
             'reliability' => 90,
 
@@ -1506,7 +1506,7 @@ class PatternAnalysisService
 
             'Cup and Handle Chart Pattern',
 
-            'Head and Shoulders Chart Patterns',
+            'Head and Shoulders Chart Pattern',
 
             'Inverse Head and Shoulders Pattern'
 
@@ -2026,7 +2026,7 @@ private function isDowntrend(array $ohlcData, int $lookback = 20): bool
 
                     return [
 
-                        'pattern_name' => 'Head and Shoulders Chart Patterns',
+                        'pattern_name' => 'Head and Shoulders Chart Pattern',
 
                         'success_probability' => $this->safeDecimalCast($patternConfig['reliability']),
 
@@ -3686,7 +3686,7 @@ private function isDowntrend(array $ohlcData, int $lookback = 20): bool
 
                 'Double Bottom Chart Pattern' => fn($data) => $this->detectDoubleBottom($data, $this->patternTypes['Double Bottom Chart Pattern']),
 
-                'Head and Shoulders Chart Patterns' => fn($data) => $this->detectHeadAndShoulders($data, $this->patternTypes['Head and Shoulders Chart Patterns']),
+                'Head and Shoulders Chart Pattern' => fn($data) => $this->detectHeadAndShoulders($data, $this->patternTypes['Head and Shoulders Chart Pattern']),
 
                 'Cup and Handle Chart Pattern' => fn($data) => $this->detectCupAndHandle($data, $this->patternTypes['Cup and Handle Chart Pattern']),
 


### PR DESCRIPTION
## Summary
- Rename `Head and Shoulders Chart Patterns` to singular `Head and Shoulders Chart Pattern`
- Update premium pattern list, detection return data, and pattern detector mappings to use singular name

## Testing
- `php -l PatternAnalysisService.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4415618348327acd992160ac308c0